### PR TITLE
Use README within docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The standard library provides the methods [`chunks`](https://doc.rust-lang.org/s
 
 The difference between `chunks` and `divide` is that you determine the size of the chunks with `chunks`, and the number of subslices you want with `divide`:
 ```rust
+use divide_slice::Divide;
+
 let slice = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 let mut iter = slice.chunks(3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,4 @@
-//! Divide_slice provides two additional methods to the primitive type [slice]:
-//!  * [`divide`]: divide a slice into `n` non-overlapping portions, returning an iterator.
-//!  * [`divide_mut`]: divide a slice into `n` mutable non-overlapping portions, returning an iterator.
-//! 
-//! [slice]: slice
-//! [`divide`]: Divide::divide
-//! [`divide_mut`]: Divide::divide_mut
-
+#![doc = include_str!("../README.md")]
 #![feature(raw_slice_split)]
 
 use std::marker::PhantomData;


### PR DESCRIPTION
This PR replaces the current `lib.rs` documentation with the README and thus ensures that the code within the README is also valid, as the <code>```rust</code> block is picked up by `cargo test`.